### PR TITLE
Add a document on handling SoC incidents

### DIFF
--- a/handling-incidents.md
+++ b/handling-incidents.md
@@ -7,7 +7,7 @@ complaints from attendees.
 ## SoC Event Committee
 
 All TPF events will have a per-event Standards of Conduct committee appointed
-to act as the final authority for all issues related to the standards of
+to act as the designated authority for all issues related to the standards of
 conduct for each event. The membership of this committee may vary from event
 to event.
 
@@ -73,6 +73,9 @@ pressure the reporter to take any action if they do not want to do it.
 * The circumstances surrounding the incident.
 * Your identity.
 * Other people involved in the incident.
+
+Please note that we typically will not take action based on a single anonymous
+complaint.
 
 ## Expulsion
 

--- a/handling-incidents.md
+++ b/handling-incidents.md
@@ -2,7 +2,8 @@
 
 This document is for event organizers and volunteers and provides guidelines
 on handling violations of the standards of conduct as well as incident
-complaints from attendees.
+complaints from attendees. The actual standards of conduct are described in a
+separate document provided to all attendees by the conference organizers.
 
 ## SoC Event Committee
 

--- a/handling-incidents.md
+++ b/handling-incidents.md
@@ -43,12 +43,12 @@ Please send all reports by email to
 ## Presentations
 
 Presentations or similar events should not be stopped for one-time gaffes or
-minor problems, although a member of the event organizer or volunteers should
-speak to the presenter afterward. However, organizers and volunteers should
-take immediate action to politely and calmly stop any presentation or event
-that repeatedly or seriously violates the anti-harassment policy. For example,
-simply say "I’m sorry, this presentation cannot be continued at the present
-time" and provide no further explanation.
+minor problems, although an event organizer or a volunteer should speak to the
+presenter afterward. However, organizers and volunteers should take immediate
+action to politely and calmly stop any presentation or event that repeatedly
+or seriously violates the anti-harassment policy. For example, simply say "I’m
+sorry, this presentation cannot be continued at the present time" and provide
+no further explanation.
 
 ## Taking reports
 

--- a/handling-incidents.md
+++ b/handling-incidents.md
@@ -77,6 +77,14 @@ pressure the reporter to take any action if they do not want to do it.
 Please note that we typically will not take action based on a single anonymous
 complaint.
 
+### Contacting Security or Local Authorities
+
+If the person reporting the incident says that they were physically hurt or
+felt afraid for their safety, then the person taking the report should offer
+to help contact venue security and local authorities. If you are taking a
+report, you are encouraged to ask the reporter if they were hurt or felt
+afraid for their safety.
+
 ## Expulsion
 
 An event participant may be expelled by the decision of SoC Event Committee
@@ -89,12 +97,12 @@ guidelines for when a participant should be expelled:
 * A single serious offense, e.g., groping someone or a physical assault.
 * A single obviously intentional offense, e.g., taking up-skirt photos.
 
-Venue security and local authorities should be contacted when appropriate.
-
 ## Public statements
 
 As a general rule, event organizer and volunteers should not make any public
 statements about the behavior of individual people during or after the event.
+
+## Summary
 
 In general, consult with the SoC committee as well as other event organizers
 and volunteers when possible, but act when necessary.

--- a/handling-incidents.md
+++ b/handling-incidents.md
@@ -96,7 +96,7 @@ guidelines for when a participant should be expelled:
 * Continuing to harass after any “no” or “stop” instruction.
 * A pattern of harassing behavior with or without warnings.
 * A single serious offense, e.g., groping someone or a physical assault.
-* A single obviously intentional offense, e.g., taking up-skirt photos.
+* A single obviously intentional and extreme offense.
 
 Participants who are expelled because of a violation of the SoC are not
 entitled to a refund of any conference fees.

--- a/handling-incidents.md
+++ b/handling-incidents.md
@@ -51,7 +51,7 @@ or seriously violates the anti-harassment policy. For example, simply say "I’m
 sorry, this presentation cannot be continued at the present time" and provide
 no further explanation.
 
-## Taking reports
+## Taking Reports
 
 Whenever possible, event organizers or volunteers should direct complaints to
 a member of the SoC Event Committee. However, that may not always be possible,
@@ -98,7 +98,10 @@ guidelines for when a participant should be expelled:
 * A single serious offense, e.g., groping someone or a physical assault.
 * A single obviously intentional offense, e.g., taking up-skirt photos.
 
-## Public statements
+Participants who are expelled because of a violation of the SoC are not
+entitled to a refund of any conference fees.
+
+## Public Statements
 
 As a general rule, event organizer and volunteers should not make any public
 statements about the behavior of individual people during or after the event.

--- a/handling-incidents.md
+++ b/handling-incidents.md
@@ -1,0 +1,101 @@
+## Handling Standards of Conduct Incidents
+
+This document is for event organizers and volunteers and provides guidelines
+on handling violations of the standards of conduct as well as incident
+complaints from attendees.
+
+## SoC Event Committee
+
+All TPF events will have a per-event Standards of Conduct committee appointed
+to act as the final authority for all issues related to the standards of
+conduct for each event. The membership of this committee may vary from event
+to event.
+
+This committee will typically include a mix of Perl Foundation board members,
+conference organizers, and community volunteers.
+
+The committee for {$event} is:
+
+* {$member_one}
+* {$member_two}
+* ...
+
+## Warnings
+
+Any event organizer or volunteer can issue a verbal warning to a participant,
+letting them know that their behavior violates the event’s standards of
+conduct. Warnings should be reported to event organizers as soon as
+practical. The report should include:
+
+* Identifying information about the participant(s) (name, appearance,
+  clothing, etc.) given a warning.
+* The time of day the warning was issued.
+* The behavior that was in violation.
+* The approximate time of the behavior (if different than the time of
+  warning).
+* The circumstances surrounding the incident.
+* Your identity.
+* Other people involved in the incident.
+
+Please send all reports by email to
+[mailto:soc@perlconference.us](soc@perlconference.us).
+
+## Presentations
+
+Presentations or similar events should not be stopped for one-time gaffes or
+minor problems, although a member of the event organizer or volunteers should
+speak to the presenter afterward. However, organizers and volunteers should
+take immediate action to politely and calmly stop any presentation or event
+that repeatedly or seriously violates the anti-harassment policy. For example,
+simply say "I’m sorry, this presentation cannot be continued at the present
+time" and provide no further explanation.
+
+## Taking reports
+
+Whenever possible, event organizers or volunteers should direct complaints to
+a member of the SoC Event Committee. However, that may not always be possible,
+and organizers or volunteers should be prepared to handle an incident report.
+
+When taking a report from someone experiencing harassment, you should record
+what they say and reassure them they are being taken seriously, but avoid
+making specific promises about what actions will be taken in response. Ask for
+any other information if the reporter has not volunteered it (such as time and
+place) but do not pressure them to provide it if they are reluctant. If the
+reporter desires it, arrange for an escort by an organizer, volunteer, or a
+trusted person, contact a friend, and contact local law enforcement. Do not
+pressure the reporter to take any action if they do not want to do it.
+
+* Identifying information about the participant(s) (name, appearance,
+  clothing, etc.) being complained about, as well as the person(s) making the
+  complaint.
+* The behavior that led to the complaint.
+* The approximate time of the incident.
+* The circumstances surrounding the incident.
+* Your identity.
+* Other people involved in the incident.
+
+## Expulsion
+
+An event participant may be expelled by the decision of SoC Event Committee
+for whatever reasons they deem sufficient. However, here are some general
+guidelines for when a participant should be expelled:
+
+* A second offense resulting in a warning.
+* Continuing to harass after any “no” or “stop” instruction.
+* A pattern of harassing behavior with or without warnings.
+* A single serious offense, e.g., groping someone or a physical assault.
+* A single obviously intentional offense, e.g., taking up-skirt photos.
+
+Venue security and local authorities should be contacted when appropriate.
+
+## Public statements
+
+As a general rule, event organizer and volunteers should not make any public
+statements about the behavior of individual people during or after the event.
+
+In general, consult with the SoC committee as well as other event organizers
+and volunteers when possible, but act when necessary.
+
+## Contact Info
+
+Email: [mailto:soc@perlconference.us](soc@perlconference.us)

--- a/standards-of-conduct.md
+++ b/standards-of-conduct.md
@@ -51,13 +51,22 @@ If anyone engages in unacceptable behavior, the conference organizers may take
 any action they deem appropriate including expulsion from the conference
 without warning or refund.
 
-## 6. What to do if you witness or are subject to unacceptable behavior
+## 6. Reporting Incidents
 
 If you are subject to unacceptable behavior, notice that someone else is being
-subject to unacceptable behavior, or have any other concerns, please notify
-[mailto:soc@perlconference.us](soc@perlconference.us) as soon as possible.
+subject to unacceptable behavior, or have any other concerns, please notify a
+member of the SoC Event Committee as soon as possible. If you do not know who
+these members are, ask any event organizer or volunteer for help. You may also
+email [mailto:soc@perlconference.us](soc@perlconference.us) to report an
+incident if you prefer.
 
-## 7. License and attribution
+## 7. Handling Incidents
+
+If you are a member of an SoC Event Committee, an event organizer, or a
+volunteer, please see our [documentation on handling
+incidents](handling-incidents.md).
+
+## 8. License and attribution
 
 [Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA
 3.0)](http://creativecommons.org/licenses/by-sa/3.0/)

--- a/standards-of-conduct.md
+++ b/standards-of-conduct.md
@@ -60,11 +60,15 @@ these members are, ask any event organizer or volunteer for help. You may also
 email [mailto:soc@perlconference.us](soc@perlconference.us) to report an
 incident if you prefer.
 
-## 7. Handling Incidents
+## 7. Standard of Conduct Committee
 
-If you are a member of an SoC Event Committee, an event organizer, or a
-volunteer, please see our [documentation on handling
-incidents](handling-incidents.md).
+Each event will establish a standards of conduct committee (SoC Committee) and
+a chairperson for that committee. The point of contact for this committee will
+be published on the event website. The SoC Committee will be responsible for
+receiving and handling all incident reports. The SoC Committee is authorized
+to establish any supplemental procedures necessary to fulfill their role,
+provided that any such procedures are subject to approval by The Perl
+Foundation.
 
 ## 8. License and attribution
 


### PR DESCRIPTION
This is a template that needs to be filled in with SoC Event Committee members
for each event.